### PR TITLE
moving secrets outs of config

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,138 @@
+# Byte-compiled / optimized / DLL files
+__pycache__/
+*.py[cod]
+*$py.class
+
+# C extensions
+*.so
+
+# Distribution / packaging
+.Python
+build/
+develop-eggs/
+dist/
+downloads/
+eggs/
+.eggs/
+lib/
+lib64/
+parts/
+sdist/
+var/
+wheels/
+share/python-wheels/
+*.egg-info/
+.installed.cfg
+*.egg
+MANIFEST
+
+# PyInstaller
+#  Usually these files are written by a python script from a template
+#  before PyInstaller builds the exe, so as to inject date/other infos into it.
+*.manifest
+*.spec
+
+# Installer logs
+pip-log.txt
+pip-delete-this-directory.txt
+
+# Unit test / coverage reports
+htmlcov/
+.tox/
+.nox/
+.coverage
+.coverage.*
+.cache
+nosetests.xml
+coverage.xml
+*.cover
+*.py,cover
+.hypothesis/
+.pytest_cache/
+cover/
+
+# Translations
+*.mo
+*.pot
+
+# Django stuff:
+*.log
+local_settings.py
+db.sqlite3
+db.sqlite3-journal
+
+# Flask stuff:
+instance/
+.webassets-cache
+
+# Scrapy stuff:
+.scrapy
+
+# Sphinx documentation
+docs/_build/
+
+# PyBuilder
+.pybuilder/
+target/
+
+# Jupyter Notebook
+.ipynb_checkpoints
+
+# IPython
+profile_default/
+ipython_config.py
+
+# pyenv
+#   For a library or package, you might want to ignore these files since the code is
+#   intended to run in multiple environments; otherwise, check them in:
+# .python-version
+
+# pipenv
+#   According to pypa/pipenv#598, it is recommended to include Pipfile.lock in version control.
+#   However, in case of collaboration, if having platform-specific dependencies or dependencies
+#   having no cross-platform support, pipenv may install dependencies that don't work, or not
+#   install all needed dependencies.
+#Pipfile.lock
+
+# PEP 582; used by e.g. github.com/David-OConnor/pyflow
+__pypackages__/
+
+# Celery stuff
+celerybeat-schedule
+celerybeat.pid
+
+# SageMath parsed files
+*.sage.py
+
+# Environments
+.env
+.venv
+env/
+venv/
+ENV/
+env.bak/
+venv.bak/
+
+# Spyder project settings
+.spyderproject
+.spyproject
+
+# Rope project settings
+.ropeproject
+
+# mkdocs documentation
+/site
+
+# mypy
+.mypy_cache/
+.dmypy.json
+dmypy.json
+
+# Pyre type checker
+.pyre/
+
+# pytype static type analyzer
+.pytype/
+
+# Cython debug symbols
+cython_debug/

--- a/README.md
+++ b/README.md
@@ -27,15 +27,20 @@ Things you need:
 
 1) Sync the repo (duh)
 2) ```pip3 install -r requirements.txt```
-3) Edit sample.conf appropriately and save as your own config filename in your favorite JSON editor. Config file Notes:
+3) Modify `.env` to reflect your **ZONEID** and **CloudFlare API TOKEN**
+```
+CFDDNS_API_TOKEN="1234KEYTOKENHERE"
+CFDDNS_ZONEID="AA-11-BB-22"
+```
+4) Edit sample.conf appropriately and save as your own config filename in your favorite JSON editor. Config file Notes:
 
     a) The configuration file interval value is in seconds.  Some useful values: (600 = 10 minutes, 1800 = 30 minutes, etc)
 
     b) interface name doesn't matter (yet) as it's not fully implemented.
-4) ```chmod u+x ./cfddns.py```
-5) ```./cfddns.py /path/to/config``` (consider running in tmux or screen until [systemd functionality](https://github.com/tomh4x/cfddns/issues/1) working)
-6) Please be mindful of hammering the API endpoints and/or ip checking servers when configuring the run interval.  I imagine a single check every 30 minutes is plenty-fast for most people.
-7) ### NOTE: the configuration file will store your API credentials.  Protect it as a private key or password.
+5) ```chmod u+x ./cfddns.py```
+6) ```./cfddns.py /path/to/config``` (consider running in tmux or screen until [systemd functionality](https://github.com/tomh4x/cfddns/issues/1) working)
+7) Please be mindful of hammering the API endpoints and/or ip checking servers when configuring the run interval.  I imagine a single check every 30 minutes is plenty-fast for most people.
+8) ### NOTE: the configuration file will store your API credentials.  Protect it as a private key or password.
 
 ### iptfw.py
 A script to maintain a dynamic whitelist on a Linux system using an `iptables` library with rules written via a JSON config file (see `ipt_sample.conf` in the repo).  The user can configure a hostname and a set of ports for which to maintain access.  The script will set rules using the IP from the hostname's `A` record and destination ports and maintain the source IP address against the `A` record as it changes.  You can see why this pairs nicely with `cfddns.py`, but it could be used for dynamic whitelists regardless of your DNS provider of choice.  Considerations:

--- a/cfconfig.py
+++ b/cfconfig.py
@@ -1,6 +1,10 @@
 #!/usr/bin/env python3
 import json
+from os import environ, path
+from dotenv import load_dotenv
 
+basedir = path.abspath(path.dirname(__file__))
+load_dotenv(path.join(basedir, '.env'))
 
 def confLoad(conf_file):
     try:
@@ -11,10 +15,10 @@ def confLoad(conf_file):
     return json.loads(fh.read())
 
 def confGetAPIToken(confstruct):
-    return confstruct['CFAuth']['API_Token']
+    return environ.get('CFDDNS_API_TOKEN')
 
 def confGetZoneID(confstruct):
-    return confstruct['CFAuth']['ZoneID']
+    return environ.get('CFDDNS_ZONEID')
 
 def confGetHost( confstruct):
     return confstruct['ddns_host']


### PR DESCRIPTION
This is a simple change but should provide a bit better method for shipping the secrets (api token, zoneid [if considered secret]) within a `.env` as variables instead of within the config.

